### PR TITLE
Replace O(n^2) string concatenation with O(n) append child

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = function() {
     parse(line);
     style();
     olog.apply(console, arguments);
-    pre.innerHTML += line + '\n';
+    pre.appendChild(document.createTextNode(line + '\n'));
   }
 
   return function undo() {
@@ -51,10 +51,16 @@ function parse(line) {
 function style() {
   var s = document.body.style;
   if (failed > 0) {
-    s.backgroundColor = colors.FAILING;
+    if (s.backgroundColor !== colors.FAILING) {
+      s.backgroundColor = colors.FAILING;
+    }
   } else if (passed > 0 && failed === 0) {
-    s.backgroundColor = colors.PASSING;
+    if (s.backgroundColor !== colors.PASSING) {
+      s.backgroundColor = colors.PASSING;
+    }
   } else {
-    s.backgroundColor = colors.PENDING;
+    if (s.backgroundColor !== colors.PENDING) {
+      s.backgroundColor = colors.PENDING;
+    }
   }
 }


### PR DESCRIPTION
This PR fixes a serious performance bug in tap-browser-color, which was causing it to take far too long on large test cases.

For example, on [regl](https://github.com/mikolalysenko/regl) running the test suite with the previous version of tap-browser-color took several minutes.  With this fix, it is now done in a few seconds.

This PR also modifies the background color updates to avoid restyling after each log event.
